### PR TITLE
feat: scroll down until the last message

### DIFF
--- a/src/components/MessageList.tsx
+++ b/src/components/MessageList.tsx
@@ -1,14 +1,29 @@
 import { Message } from "../types";
+import { useRef, useEffect } from "react";
 
 interface MessageListProps {
     messages: Message[];
 }
 
 const MessageList: React.FC<MessageListProps> = ({ messages }) => {
+
+    // Ref to keep track of the last message
+    const lastMessageRef = useRef<HTMLDivElement | null>(null);
+
+    // Scroll to the last message whenever messages change
+    useEffect(() => {
+        if(lastMessageRef.current) {
+            lastMessageRef.current.scrollIntoView({ behavior: "smooth"});
+        }
+    }, [messages]);
+
     return (
         <div className="message-list">
-            {messages.map((message) => (
-                <div key={message.id} className={`message ${message.author === "ChatGPT" ? "ChatGPT" : "user"}`}>
+            {messages.map((message, index) => (
+                <div 
+                    key={message.id} 
+                    className={`message ${message.author === "ChatGPT" ? "ChatGPT" : "user"}`}
+                    ref={index === messages.length -1 ? lastMessageRef : null }>
                     <p>{message.content}</p>
                 </div>
             ))}


### PR DESCRIPTION
When there are several messages the message list stays on top and we cannot see the last messages. We need to scroll down manually.
This PR modifies the MessageList component to apply a scroll down until the last message by default.